### PR TITLE
Xkcd https

### DIFF
--- a/devbot/src/scripts/xkcd.coffee
+++ b/devbot/src/scripts/xkcd.coffee
@@ -10,7 +10,6 @@
 # Commands:
 #   hubot xkcd - The latest XKCD comic
 #   hubot xkcd #<num> - XKCD comic <num>
-#   hubot xkcd ? - XKCD comic <num>
 #   hubot xkcd <phrase> - XKCD comic relevant to <phrase>
 #
 # Author:
@@ -19,11 +18,11 @@
 #   Kelvin Zhang <me@iamkelv.in> (hubot-relevant-xkcd)
 #
 # Modified
-# beforan (changed commands to make relevant search easier and merged Kelvin's relevant script into here')
+# beforan (changed commands to make relevant search easier and merged Kelvin's relevant script into here)
 
 module.exports = (robot) ->
-  robot.respond /xkcd?$/i, (msg) ->
-    msg.http("http://xkcd.com/info.0.json")
+  robot.respond /xkcd$/i, (msg) ->
+    msg.http("https://xkcd.com/info.0.json")
       .get() (err, res, body) ->
         if res.statusCode == 404
           msg.send 'Comic not found.'
@@ -34,7 +33,7 @@ module.exports = (robot) ->
   robot.respond /xkcd\s+#(\d+)/i, (msg) ->
     num = "#{msg.match[1]}"
 
-    msg.http("http://xkcd.com/#{num}/info.0.json")
+    msg.http("https://xkcd.com/#{num}/info.0.json")
       .get() (err, res, body) ->
         if res.statusCode == 404
           msg.send 'Comic #{num} not found.'
@@ -43,14 +42,14 @@ module.exports = (robot) ->
           msg.send object.title, object.img, object.alt
 
   robot.respond /xkcd\s+\?/i, (msg) ->
-    msg.http("http://xkcd.com/info.0.json")
+    msg.http("https://xkcd.com/info.0.json")
           .get() (err,res,body) ->
             if res.statusCode == 404
                max = 0
             else
                max = JSON.parse(body).num 
                num = Math.floor((Math.random()*max)+1)
-               msg.http("http://xkcd.com/#{num}/info.0.json")
+               msg.http("https://xkcd.com/#{num}/info.0.json")
                .get() (err, res, body) ->
                  object = JSON.parse(body)
                  msg.send object.title, object.img, object.alt
@@ -70,7 +69,7 @@ module.exports = (robot) ->
         comicNumber = parseInt(responseData[2], 10)
 
         # Get the comic details from XKCD
-        msg.http("http://xkcd.com/#{comicNumber}/info.0.json")
+        msg.http("https://xkcd.com/#{comicNumber}/info.0.json")
         .get() (err, res, body) ->
           if res.statusCode == 404
             msg.send 'Comic #{comicNumber} not found.'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,3 +2,5 @@ devbot:
     build: devbot
     environment:
         - HUBOT_SLACK_TOKEN
+    volumes:
+        - ./devbot/src/scripts:/opt/devbot/scripts


### PR DESCRIPTION
randall's changed `xkcd.com` to serve only on HTTPS - accessing `xkcd.com` on port 80 results in a redirect response.

our xkcd scripts was, of course, hitting the site over HTTP, and wasn't following the redirect.

I've updated to get it to hit https and this script is all working again :)