### PR TITLE
added the `xkcd ?` command back into the docs

### DIFF
--- a/devbot/src/scripts/xkcd.coffee
+++ b/devbot/src/scripts/xkcd.coffee
@@ -11,6 +11,7 @@
 #   hubot xkcd - The latest XKCD comic
 #   hubot xkcd #<num> - XKCD comic <num>
 #   hubot xkcd <phrase> - XKCD comic relevant to <phrase>
+#   hubot xkcd ? - random xkcd comic
 #
 # Author:
 #   twe4ked
@@ -76,4 +77,3 @@ module.exports = (robot) ->
           else
             object = JSON.parse(body)
             msg.send object.title, object.img, object.alt
-


### PR DESCRIPTION
what it says on the tin.

I removed this in the last xkcd script change, because the documentation (in the script header comments) was wrong.

It's now back, and correct!